### PR TITLE
Fix quote update

### DIFF
--- a/app/src/main/java/com/cmp/pushuptracker/ui/screen/home/GetHomeSection.kt
+++ b/app/src/main/java/com/cmp/pushuptracker/ui/screen/home/GetHomeSection.kt
@@ -63,8 +63,9 @@ fun GetHomeSection(userViewmodel: UserViewmodel, pushupViewModel: PushupViewMode
     Spacer(Modifier.height(10.dp))
     GetChallengeCard(pushupViewModel)
     Spacer(Modifier.height(25.dp))
+    val quote = remember { getRandomQuote() }
     Text(
-        "\"${getRandomQuote()}\"",
+        "\"$quote\"",
         fontFamily = workSansFamily,
         fontWeight = FontWeight.Normal,
         fontSize = 14.sp,


### PR DESCRIPTION
## Summary
- cache random quote with `remember` so it only changes on recomposition

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_6886379ba818832fb85684c8f140a20f