### PR TITLE
Fix illustration state update

### DIFF
--- a/app/src/main/java/com/cmp/pushuptracker/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/cmp/pushuptracker/ui/screen/home/HomeScreen.kt
@@ -159,7 +159,7 @@ fun GetHomePushupCard(
     illustrationType: PushupIllustrations,
     canShowIllustration: Boolean = true
 ) {
-    val illustration = remember {
+    val illustration = remember(illustrationType) {
         when (illustrationType) {
             PushupIllustrations.ONE -> R.drawable.pushup_one
             PushupIllustrations.TWO -> R.drawable.pushup_two


### PR DESCRIPTION
## Summary
- update `GetHomePushupCard` to key the remembered image by `illustrationType`

## Testing
- `./gradlew test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68863b635f60832f98ba214f53795351