### PR TITLE
Fix date range recalculation in calendar view

### DIFF
--- a/app/src/main/java/com/cmp/pushuptracker/ui/components/PushupCalendarView.kt
+++ b/app/src/main/java/com/cmp/pushuptracker/ui/components/PushupCalendarView.kt
@@ -45,7 +45,9 @@ fun GetHabitCalendarView(
     pushupMap: Map<String, PushUpEntity>,
     onClick: (PushUpEntity?) -> Unit
 ) {
-    val days = TimeUtils.getDateRangeLastSundayToThisSaturday("dd/MM/YYYY", 13)
+    val days = remember {
+        TimeUtils.getDateRangeLastSundayToThisSaturday("dd/MM/YYYY", 13)
+    }
     val daysList = remember {
         listOf(
             "Su",


### PR DESCRIPTION
## Summary
- cache the list of days for the calendar view using `remember`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68863b6606dc832fb65d38ba99d88900