### PR TITLE
Remove unused import

### DIFF
--- a/app/src/main/java/com/cmp/pushuptracker/ui/screen/history/GetHeatMap.kt
+++ b/app/src/main/java/com/cmp/pushuptracker/ui/screen/history/GetHeatMap.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp


### PR DESCRIPTION
## Summary
- clean up `GetHeatMap.kt` imports by removing `LaunchedEffect`

## Testing
- `./gradlew test --no-daemon --no-build-cache --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68863b66f300832f99440d53e99a9428