### PR TITLE
Remove sluggish fade-in transition in bottom navigation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui)

--- a/app/src/main/java/com/cmp/pushuptracker/MainActivity.kt
+++ b/app/src/main/java/com/cmp/pushuptracker/MainActivity.kt
@@ -5,12 +5,10 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -108,7 +106,6 @@ class MainActivity : ComponentActivity() {
     }
 }
 
-@OptIn(ExperimentalAnimationApi::class)
 @Composable
 fun PushUpAppNavigation(
     utilViewmodel: UtilViewmodel,
@@ -122,8 +119,7 @@ fun PushUpAppNavigation(
         NavHost(
             navController = navController,
             startDestination = Screen.Home.route,
-            modifier = Modifier.padding(innerPadding),
-            enterTransition = { fadeIn(tween(500)) }
+            modifier = Modifier.padding(innerPadding)
         ) {
             composable(Screen.Home.route) {
                 HomeScreen(

--- a/app/src/main/java/com/cmp/pushuptracker/ui/screen/history/HistoryScreen.kt
+++ b/app/src/main/java/com/cmp/pushuptracker/ui/screen/history/HistoryScreen.kt
@@ -8,13 +8,12 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
@@ -28,14 +27,14 @@ fun HistoryScreen(
     navController: NavHostController,
     pushupViewModel: PushupViewModel,
 ) {
-    val pushupDataState by pushupViewModel.pushupData.collectAsState()
+    val pushupDataState by pushupViewModel.pushupData.collectAsStateWithLifecycle()
 
     var selectedDate by rememberSaveable { mutableStateOf<PushUpEntity?>(null) }
     var canShowInfoBottomSheet by rememberSaveable { mutableStateOf(false) }
 
-    val datePushupMap by rememberUpdatedState(
-        newValue = pushupDataState.associateBy { it.date }
-    )
+    val datePushupMap = remember(pushupDataState) {
+        pushupDataState.associateBy { it.date }
+    }
 
     LaunchedEffect(Unit) {
         Log.d("flowTag", "Inside History")

--- a/app/src/main/java/com/cmp/pushuptracker/ui/screen/history/HistoryScreen.kt
+++ b/app/src/main/java/com/cmp/pushuptracker/ui/screen/history/HistoryScreen.kt
@@ -1,10 +1,10 @@
 package com.cmp.pushuptracker.ui.screen.history
 
 import android.util.Log
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -35,6 +35,7 @@ fun HistoryScreen(
     val datePushupMap = remember(pushupDataState) {
         pushupDataState.associateBy { it.date }
     }
+    val scrollState = rememberSaveable(saver = ScrollState.Saver) { ScrollState(0) }
 
     LaunchedEffect(Unit) {
         Log.d("flowTag", "Inside History")
@@ -45,8 +46,7 @@ fun HistoryScreen(
             navController.popBackStack()
         }
         Column(
-            modifier = Modifier
-                .verticalScroll(rememberScrollState())
+            modifier = Modifier.verticalScroll(scrollState)
         ) {
             Spacer(Modifier.height(16.dp))
             GetHeatMap(datePushupMap) {

--- a/app/src/main/java/com/cmp/pushuptracker/ui/screen/home/GetHomeSection.kt
+++ b/app/src/main/java/com/cmp/pushuptracker/ui/screen/home/GetHomeSection.kt
@@ -15,12 +15,11 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -45,10 +44,10 @@ import com.cmp.pushuptracker.viewmodel.UserViewmodel
 
 @Composable
 fun GetHomeSection(userViewmodel: UserViewmodel, pushupViewModel: PushupViewModel) {
-    val pushupDataState by pushupViewModel.pushupData.collectAsState()
-    val datePushupMap by rememberUpdatedState(
-        newValue = pushupDataState.associateBy { it.date }
-    )
+    val pushupDataState by pushupViewModel.pushupData.collectAsStateWithLifecycle()
+    val datePushupMap = remember(pushupDataState) {
+        pushupDataState.associateBy { it.date }
+    }
 
     var selectedDate by remember { mutableStateOf<PushUpEntity?>(null) }
     var canShowInfoBottomSheet by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/cmp/pushuptracker/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/cmp/pushuptracker/ui/screen/home/HomeScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,7 +18,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
@@ -79,7 +79,7 @@ fun HomeScreen(
 ) {
     val pushupData = pushupViewModel.todayData
     var showQuickAddShet by rememberSaveable { mutableStateOf(false) }
-    val scrollState = rememberScrollState()
+    val scrollState = rememberSaveable(saver = ScrollState.Saver) { ScrollState(0) }
     var isScrollingUp by remember { mutableStateOf(true) }
 
     LaunchedEffect(Unit) {

--- a/app/src/main/java/com/cmp/pushuptracker/ui/screen/profileScreen/ProfileScreen.kt
+++ b/app/src/main/java/com/cmp/pushuptracker/ui/screen/profileScreen/ProfileScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -22,13 +23,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
@@ -130,10 +131,11 @@ fun ProfileScreen(
             homeNavController.popBackStack()
         }
         Spacer(Modifier.height(10.dp))
+        val scrollState = rememberSaveable(saver = ScrollState.Saver) { ScrollState(0) }
         Column(
             modifier = Modifier
                 .padding(horizontal = 16.dp)
-                .verticalScroll(rememberScrollState()),
+                .verticalScroll(scrollState),
             verticalArrangement = Arrangement.spacedBy(18.dp)
         ) {
             GetStatsSection(userData)

--- a/app/src/main/java/com/cmp/pushuptracker/viewmodel/PushUpViewmodel.kt
+++ b/app/src/main/java/com/cmp/pushuptracker/viewmodel/PushUpViewmodel.kt
@@ -24,7 +24,7 @@ class PushupViewModel @Inject constructor(
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5_000),
-            initialValue = listOf(PushUpEntity("", 0, 0, 0))
+            initialValue = emptyList()
         )
 
     var todayData by mutableStateOf<PushUpEntity?>(null)

--- a/app/src/main/java/com/cmp/pushuptracker/viewmodel/UserViewmodel.kt
+++ b/app/src/main/java/com/cmp/pushuptracker/viewmodel/UserViewmodel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.viewModelScope
 import com.cmp.pushuptracker.database.entity.UserEntity
 import com.cmp.pushuptracker.database.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -28,9 +29,8 @@ class UserViewmodel @Inject constructor(
     fun updateUserData(user: UserEntity) {
         viewModelScope.launch {
             repository.updateSession(user)
-            repository.getUserDataFromDb().collect {
-                userData = it.firstOrNull() ?: UserEntity()
-            }
+            val updated = repository.getUserDataFromDb().firstOrNull()?.firstOrNull()
+            userData = updated ?: UserEntity()
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,6 +50,7 @@ hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hil
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntimeKtx" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }


### PR DESCRIPTION
## Summary
- streamline bottom navigation by removing 500ms fade-in transition
- drop experimental animation opt-in and unused imports
- collect flows with lifecycle awareness and avoid recomputing derived maps
- simplify viewmodel state initialization and flow collection

## Testing
- ⚠️ `./gradlew test` *(SDK location not found: Define a valid SDK location with an ANDROID_HOME environment variable or by setting the sdk.dir path)*

------
https://chatgpt.com/codex/tasks/task_b_68a02e0b67fc832fbb5fc89fe0a3c2a6